### PR TITLE
kubernetes-helmPlugins: build rather than download

### DIFF
--- a/pkgs/applications/networking/cluster/helm/plugins/default.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/default.nix
@@ -1,36 +1,11 @@
-{ stdenv, fetchFromGitHub, fetchurl, fetchzip }:
-let
+{ callPackage }:
 
-  buildHelmPlugin = { name, ... }@attrs:
-    fetchzip (attrs // {
-      stripRoot = false;
-    });
-in {
+{
 
-  helm-s3 = let
-    pname = "helm-s3";
-    version = "0.10.0";
-  in buildHelmPlugin rec {
-    name = "${pname}-${version}";
-    url = "https://github.com/hypnoglow/helm-s3/releases/download/v${version}/helm-s3_${version}_linux_amd64.tar.gz";
-    sha256 = "sha256-pTux7HArWB5yO1Oehfd+ZpeGUziI2+wfUart5WfkQW4=";
+  helm-diff = callPackage ./helm-diff.nix {};
 
-    extraPostFetch = ''
-      mkdir $out/${pname}
-      GLOBIGNORE="$out/${pname}"
-      mv $out/* -t $out/${pname}
-    '';
-  };
+  helm-s3 = callPackage ./helm-s3.nix {};
 
-  helm-diff = buildHelmPlugin {
-    name = "helm-diff";
-    url = "https://github.com/databus23/helm-diff/releases/download/v3.1.3/helm-diff-linux.tgz";
-    sha256 = "sha256-oGmBPcCyUgq2YD4+CkGrbf6/JhzXJjmkaiqX/3a03aE=";
-  };
+  helm-secrets = callPackage ./helm-secrets.nix {};
 
-  helm-secrets = buildHelmPlugin {
-    name = "helm-secrets";
-    url = "https://github.com/jkroepke/helm-secrets/releases/download/v3.4.1/helm-secrets.tar.gz";
-    sha256 = "sha256-HXwbs/bXJXF75FbLB/En0jirCQnz8HpU3o9LeMyV0e8=";
-  };
 }

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-diff.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-diff.nix
@@ -1,0 +1,35 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "helm-diff";
+  version = "3.1.3";
+
+  src = fetchFromGitHub {
+    owner = "databus23";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-h26EOjKNrlcrs2DAYj0NmDRgNRKozjfw5DtxUgHNTa4=";
+  };
+
+  vendorSha256 = "sha256-+n/QBuZqtdgUkaBG7iqSuBfljn+AdEzDoIo5SI8ErQA=";
+
+  # NOTE: Remove the install and upgrade hooks.
+  postPatch = ''
+    sed -i '/^hooks:/,+2 d' plugin.yaml
+  '';
+
+  postInstall = ''
+    install -dm755 $out/${pname}
+    mv $out/bin $out/${pname}/
+    mv $out/${pname}/bin/{helm-,}diff
+    install -m644 -Dt $out/${pname} plugin.yaml
+  '';
+
+  meta = with lib; {
+    description = "A Helm plugin that shows a diff";
+    inherit (src.meta) homepage;
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ yurrriq ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-s3.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-s3.nix
@@ -1,0 +1,38 @@
+{ buildGoModule, fetchFromGitHub, lib }:
+
+buildGoModule rec {
+  pname = "helm-s3";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "hypnoglow";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-2BQ/qtoL+iFbuLvrJGUuxWFKg9u1sVDRcRm2/S0mgyc=";
+  };
+
+  vendorSha256 = "sha256-/9TiY0XdkiNxW5JYeC5WD9hqySCyYYU8lB+Ft5Vm96I=";
+
+  # NOTE: Remove the install and upgrade hooks.
+  postPatch = ''
+    sed -i '/^hooks:/,+2 d' plugin.yaml
+  '';
+
+  checkPhase = ''
+    make test-unit
+  '';
+
+  postInstall = ''
+    install -dm755 $out/${pname}
+    mv $out/bin $out/${pname}/
+    install -m644 -Dt $out/${pname} plugin.yaml
+  '';
+
+  meta = with lib; {
+    description = "A Helm plugin that shows a diff";
+    inherit (src.meta) homepage;
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ yurrriq ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/applications/networking/cluster/helm/plugins/helm-secrets.nix
+++ b/pkgs/applications/networking/cluster/helm/plugins/helm-secrets.nix
@@ -1,0 +1,44 @@
+{ lib, stdenv, fetchFromGitHub, makeWrapper, coreutils, findutils, getopt, gnugrep, gnused, sops, vault }:
+
+stdenv.mkDerivation rec {
+  pname = "helm-secrets";
+  version = "3.4.1";
+
+  src = fetchFromGitHub {
+    owner = "jkroepke";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-EXCr0QjupsBBKTm6Opw5bcNwAD4FGGyOiqaa8L91/OI=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ getopt sops ];
+
+  # NOTE: helm-secrets is comprised of shell scripts.
+  dontBuild = true;
+
+  # NOTE: Remove the install and upgrade hooks.
+  postPatch = ''
+    sed -i '/^hooks:/,+2 d' plugin.yaml
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -dm755 $out/${pname} $out/${pname}/scripts
+    install -m644 -Dt $out/${pname} plugin.yaml
+    cp -r scripts/* $out/${pname}/scripts
+    wrapProgram $out/${pname}/scripts/run.sh \
+        --prefix PATH : ${lib.makeBinPath [ coreutils findutils getopt gnugrep gnused sops vault ]}
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A Helm plugin that helps manage secrets";
+    inherit (src.meta) homepage;
+    license = licenses.apsl20;
+    maintainers = with maintainers; [ yurrriq ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
###### Motivation for this change

Build rather than download Helm plugins, which has the added (and desired) side effect of supporting Darwin.

###### Things done

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
